### PR TITLE
Nicer startup

### DIFF
--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -769,8 +769,8 @@ ByVal lpstrReturnString As String, ByVal uReturnLength As Integer, ByVal hwndCal
 		End If
 
 
-		FrmSettings.Show()
-		FrmSettings.FrmSettingsLoading = True
+        'FrmSettings.Show()
+        FrmSettings.FrmSettingsLoading = True
 
 		FrmSettings.FrmSettingStartUp()
 

--- a/Tease AI/Form2.vb
+++ b/Tease AI/Form2.vb
@@ -11948,7 +11948,7 @@ WhyUMakeMeDoDis:
 
         Debug.Print("done")
 
-        MessageBox.Show(Me, PBMaintenance.Maximum & " scripts have been audited." & Environment.NewLine & Environment.NewLine &
+        MessageBox.Show(If(Me.Visible, Me, FrmSplash), PBMaintenance.Maximum & " scripts have been audited." & Environment.NewLine & Environment.NewLine &
                         "Blank lines cleared: " & BlankAudit & Environment.NewLine & Environment.NewLine &
                         "Script errors corrected: " & ErrorAudit, "Success!", MessageBoxButtons.OK, MessageBoxIcon.Information)
 


### PR DESCRIPTION
The settings window is no longer displayed at startup. The report message of the script Audit will now be displayed on the splash screen and can't disappears behind it.