### PR TITLE
URL-File-Review-Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # User-specific files
 *.suo
+*.sln
 *.user
 *.userosscache
 *.sln.docstates

--- a/Tease AI/Classes/URL_Files_BGW.vb
+++ b/Tease AI/Classes/URL_Files_BGW.vb
@@ -1,0 +1,860 @@
+﻿'===========================================================================================
+'
+'                                       URL-Files
+'
+'
+'           This File contains all Functions to Create und Maintain URL-Files.
+'
+' Uses modified and unmodified Code from Tease-AI: https://github.com/Milo1885/Tease-AI.git
+'===========================================================================================
+Imports System.ComponentModel
+Imports System.IO
+Imports System.Net
+Imports System.Xml
+
+Namespace URL_Files
+
+	''' =========================================================================================================
+	''' <summary>
+	''' This Enumeration contains the steps during the working on a URL-File.
+	''' </summary>
+	Public Enum WorkingStages
+		Started = 0
+		Dupe_Liste = 10
+		Scraping = 50
+		Blog_Scraping = 60
+		''' <summary>
+		''' The BGW is waiting for an Userinput, what to to with the Image. If you use a remanent Variable to feeed it don't forget to reset it.
+		''' </summary>
+		ImageApproval = 70
+		Writing_File = 90
+		Completed = 100
+	End Enum
+
+	''' =========================================================================================================
+	''' <summary>
+	''' This Enumeration Contains all predefined Functions.
+	''' </summary>
+	Public Enum URL_File_Tasks
+		''' <summary>
+		''' The BGW is free to use, for general usage.
+		''' </summary>
+		Idle
+		''' <summary>
+		''' Creates a new URL-File, with UserInteractions.
+		''' If it runs not the first time and is not cancelled Dead-URLs will be removed
+		''' </summary>
+		CreateURLFile
+		''' <summary>
+		''' Refreshes all URL-Files and automatically adds new URLs.
+		''' If not Cancelled, it will remove Dead-URLs.
+		''' </summary>
+		RefreshURLFiles
+		''' <summary>
+		''' Checks all URls in the URL-File-Folder. No new URLs will be added, dead one removed.
+		''' If cancelled, all was for nothing...
+		''' </summary>
+		RebuildURLFiles
+	End Enum
+
+	''' =========================================================================================================
+	''' <summary>
+	''' Enumeration for Image Approval.
+	''' </summary>
+	Public Enum ImageApprovalStatus
+		''' <summary>
+		''' IF an Image is waiting for Approval, loop till the end of Time or another State. cancellation is Possible in loop.
+		''' </summary>
+		Pending = 0
+		''' <summary>
+		''' The actual Image-URL, will be written to URL-File and saved if in <see cref="URL_File_BGW.URL_FileCreate_UserInteractions">Event</see> set.
+		''' </summary>
+		Approved = 1
+		''' <summary>
+		''' The actual Image-URL, will be written to Dislike File if set in <see cref="URL_File_BGW.DislikeListPath">Property</see>.
+		''' </summary>
+		Declined = 2
+	End Enum
+
+	''' =========================================================================================================
+	''' <summary>
+	''' Class that extends the <see cref="BackgroundWorker">Backgroundworker</see> to create and maintain URL-Files.
+	''' </summary>
+	Public Class URL_File_BGW
+		Inherits BackgroundWorker
+
+#Region "-----------------------------------------  Inherited from BackgroundWorker -------------------------------------------"
+
+		Sub New()
+			Me.WorkerSupportsCancellation = True
+			Me.WorkerReportsProgress = True
+		End Sub
+
+		''' =========================================================================================================
+		''' <summary>
+		''' Executes the Function needed.
+		''' </summary>
+		''' <param name="sender"></param>
+		''' <param name="e"></param>
+		Private Sub Me_DoWork(sender As Object, e As DoWorkEventArgs) Handles MyBase.DoWork
+			Try
+				Select Case _Work
+					Case URL_File_Tasks.CreateURLFile
+						e.Result = BlogToUrlFile()
+					Case URL_File_Tasks.RefreshURLFiles, URL_File_Tasks.RebuildURLFiles
+						e.Result = MaintainURLFiles()
+				End Select
+			Catch ex As Exception
+				'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+				'                                            All Errors
+				'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+				' Beware: While Debugging this Point VS will moan about an unhandled Exception. This is a known VS Bug.
+				e.Cancel = True
+				Throw
+			End Try
+		End Sub
+
+		Private Sub TAI_Backgroundworker_RunWorkerCompleted(sender As Object, e As RunWorkerCompletedEventArgs) Handles Me.RunWorkerCompleted
+			Try
+				If e.Error IsNot Nothing Then Throw e.Error
+
+				_BGW_Result = e
+			Catch ex As Exception
+				Throw
+			End Try
+		End Sub
+#End Region
+
+#Region "------------------------------------------------- Visible Properties -------------------------------------------------"
+
+		''' =========================================================================================================
+		''' <summary>
+		''' Stores the Target Directory of the URL-File to Create.
+		''' </summary>
+		Private _ImageURLFileDir As String = "Images\System\URL Files\"
+		''' <summary>
+		''' Gets or Sets the Target Directory of the URL-File to Create.
+		''' </summary>
+		''' <returns>Returns the Target Directory of the URL-File to Create.</returns>
+		<System.ComponentModel.Category("Behavior"),
+System.ComponentModel.Description("Determines the Target Directory of the URL-File.")>
+		Public Property ImageURLFileDir As String
+			Get
+				Return _ImageURLFileDir
+			End Get
+			Set(value As String)
+				If System.IO.Directory.Exists(value) Or Me.DesignMode = True Then
+					_ImageURLFileDir = value
+				Else
+					Throw New DirectoryNotFoundException(String.Format("Can't find the given directory: '{0}'", value))
+				End If
+			End Set
+		End Property
+
+		''' =========================================================================================================
+		''' <summary>
+		''' Stores the Filepath to Dislikelist.
+		''' </summary>
+		<System.ComponentModel.Category("Behavior"),
+System.ComponentModel.Description("Gets or Sets the Filepath to the Dislikelist.")>
+		Private _DislikeListPath As String = "Images\System\DislikedImageURLs.txt"
+		''' <summary>
+		''' Gets or Sets the Filepath To the Dislikelist.
+		''' </summary>
+		''' <returns>Returns the Filepath to the Dislikelist.</returns>
+		Public Property DislikeListPath As String
+			Get
+				Return _DislikeListPath
+			End Get
+			Set(value As String)
+				If System.IO.File.Exists(value) Or Me.DesignMode = True Then
+					_DislikeListPath = value
+				Else
+					Throw New DirectoryNotFoundException(String.Format("Can't find the given directory: '{0}'", value))
+				End If
+			End Set
+		End Property
+		''' =========================================================================================================
+		''' <summary>
+		''' Stores the Filepath to Likelist.
+		''' </summary>
+		Private _LikeListPath As String = "Images\System\LikedImageURLs.txt"
+		''' <summary>
+		''' Gets or Sets the Filepath to the Likelist.
+		''' </summary>
+		''' <returns>Returns the Filepath to the Likelist.</returns>
+		<System.ComponentModel.Category("Behavior"),
+System.ComponentModel.Description("Gets or Sets the Filepath to the Likelist.")>
+		Public Property LikeListPath As String
+			Get
+				Return _LikeListPath
+			End Get
+			Set(value As String)
+				If System.IO.File.Exists(value) Or Me.DesignMode = True Then
+					_LikeListPath = value
+				Else
+					Throw New DirectoryNotFoundException(String.Format("Can't find the given directory: '{0}'", value))
+				End If
+			End Set
+		End Property
+
+#End Region
+
+#Region "------------------------------------------------ Internal Variables --------------------------------------------------"
+
+		''' =========================================================================================================
+		''' <summary>
+		''' Stores the Result of a asynchronous Operation for marshalled use inside the Instance.
+		''' </summary>
+		Private _BGW_Result As RunWorkerCompletedEventArgs = Nothing
+		''' =========================================================================================================
+		''' <summary>
+		''' Stores the Work to do, or actually is running for marshalled use inside the Instance.
+		''' </summary>
+		Private _Work As URL_File_Tasks = URL_File_Tasks.Idle
+
+		Private _OverallProgress As Integer = 0
+
+		Private _OverallProgressTotal As Integer = 0
+
+		Private _InfoText As String = String.Empty
+
+		Private _ImageCountAdded As Integer = 0
+
+#End Region
+
+#Region "--------------------------------------------- URL_File_ProgessChanged ------------------------------------------------"
+
+		''' =========================================================================================================
+		''' <summary>
+		''' Returns the actual Backgroundworker-Progress when creating a URL-File.
+		''' </summary>
+		''' <param name="e">The Object which contains the Data.</param>
+		''' <seealso cref="URL_File_ProgressChangedEventArgs"/>
+		''' <remarks>This Event is triggered in the WorkerThread. Make sure to invoke the EventHandler Sub or Func.</remarks>
+		Public Event URL_File_ProgressChanged(Sender As Object, ByRef e As URL_File_ProgressChangedEventArgs)
+		''' =========================================================================================================
+		''' <summary>
+		''' Delegate to Invoke the URL_FileCreate_ProgressChanged-EventHandler.
+		''' </summary>
+		''' <param name="sender">The calling Class-Instance.</param>
+		''' <param name="e">The Object which contains the Data.</param>
+		Public Delegate Sub URL_File_ProgressChanged_Delegate(ByVal Sender As Object, ByRef e As URL_File_ProgressChangedEventArgs)
+		''' =========================================================================================================
+		''' <summary>
+		''' Class to carry the Data of <see cref="URL_File_ProgressChangedEventArgs">
+		''' URL_FileCreate_ProgressChangedEventArgs</see>/> from WorkerThread to MainTread.
+		''' </summary>
+		Public Class URL_File_ProgressChangedEventArgs
+			Inherits System.EventArgs
+
+			Public CurrentTask As URL_File_Tasks = URL_File_Tasks.Idle
+			Public ImageCount As Integer = 0
+			Public BlogPage As Integer = 0
+			Public BlogPageTotal As Integer = 0
+			Public ActStage As WorkingStages = WorkingStages.Completed
+			Public ImageToReview As Image = Nothing
+			Public OverallProgress As Integer = 0
+			Public OverallProgressTotal As Integer = 0
+			Public InfoText As String = Nothing
+		End Class
+		''' =========================================================================================================
+		''' <summary>
+		''' This function raises the <see cref="URL_File_ProgressChanged">URL_FileCreate_ProgressChanged</see>.
+		''' </summary>
+		''' <param name="ImageCount"></param>
+		''' <param name="BlogPage"></param>
+		''' <param name="BlogPageTotal"></param>
+		''' <param name="ActStage"></param>
+		''' <param name="ImageToReview"></param>
+		Private Sub URL_FileCreate_OnProgressChanged(ByVal ImageCount As Integer,
+												ByVal BlogPage As Integer,
+												ByVal BlogPageTotal As Integer,
+												ByVal ActStage As WorkingStages,
+												ByVal ImageToReview As Image)
+			If ActStage = WorkingStages.Writing_File Then _ImageCountAdded += ImageCount
+			Dim e As New URL_File_ProgressChangedEventArgs With
+		{
+		.CurrentTask = Me._Work,
+		.ImageCount = ImageCount,
+		.BlogPage = BlogPage,
+		.BlogPageTotal = BlogPageTotal,
+		.ActStage = ActStage,
+		.ImageToReview = ImageToReview,
+		.OverallProgress = Me._OverallProgress,
+		.OverallProgressTotal = Me._OverallProgressTotal,
+		.InfoText = Me._InfoText
+		}
+			' If  Cancel is requested and the actual Stage is Writing File, then say it that way.
+			If Me.CancellationPending And ActStage = WorkingStages.Writing_File Then _
+		e.InfoText = "Cancel requested: " & vbCrLf & "Writing File " & e.InfoText
+			RaiseEvent URL_File_ProgressChanged(Me, e)
+		End Sub
+
+#End Region
+
+#Region "----------------------------------------- URL_FileCreate_UserInteractions --------------------------------------------"
+
+		''' =========================================================================================================
+		''' <summary>
+		''' Event to receive Data from the mainprogram while creating a URL-File.
+		''' </summary>
+		''' <param name="sender">The calling Class-Instance.</param>
+		''' <param name="e">The Object which contains the Data.</param>
+		''' <remarks>This Event is triggered in the WorkerThread. Make sure to invoke the EventHandler Sub or Func.</remarks>
+		Public Event URL_FileCreate_UserInteractions(ByVal Sender As URL_File_BGW, ByRef e As UserActions)
+		''' =========================================================================================================
+		''' <summary>
+		''' Delegate to Invoke the URLCreate_UserInteractions-EventHandler.
+		''' </summary>
+		''' <param name="sender">The calling Class-Instance.</param>
+		''' <param name="e">The Object which contains the Data.</param>
+		Public Delegate Sub URL_FileCreate_UserInteractions_Delegate(ByVal Sender As URL_File_BGW, ByRef e As URL_File_BGW.UserActions)
+
+		Public Class UserActions
+			Public ReviewImages As Boolean
+			Public ApproveImage As ImageApprovalStatus
+			Public SaveImages As Boolean
+			Public ImgSaveDir As String
+		End Class
+
+		''' <summary>
+		''' Raises the <see cref="URL_FileCreate_UserInteractions_Delegate">URL_FileCreate_UserInteractions_Delegate</see>-Event.
+		''' </summary>
+		''' <returns></returns>
+		Private Function OnURL_FileCreate_UserInteractions() As UserActions
+			' Raise this Event only, while Creating an URL-File
+			Dim e As New UserActions
+			If Me._Work <> URL_File_Tasks.CreateURLFile Then
+				' Imitate User ^^
+				e.ApproveImage = True
+				e.SaveImages = False
+				e.ImgSaveDir = ""
+				e.ReviewImages = False
+			Else
+				' Really ask him 
+				RaiseEvent URL_FileCreate_UserInteractions(Me, e)
+			End If
+			Return e
+		End Function
+		''' =========================================================================================================
+		''' <summary>
+		''' If the User wants to review every image before adding. 
+		''' </summary>
+		''' <returns></returns>
+		''' <remarks>For internal Use only.</remarks>
+		Private ReadOnly Property ReviewImages As Boolean
+			Get
+				Return OnURL_FileCreate_UserInteractions.ReviewImages
+			End Get
+		End Property
+		''' =========================================================================================================
+		''' <summary>
+		''' Returns the actual Image Aproval Status, from the Main Programm
+		''' </summary>
+		''' <returns></returns>
+		''' <remarks>For internal Use only.</remarks>
+		Private ReadOnly Property ApproveImage As ImageApprovalStatus
+			Get
+				Return OnURL_FileCreate_UserInteractions.ApproveImage
+			End Get
+		End Property
+		''' =========================================================================================================
+		''' <summary>
+		''' Returns whether the image on the plate should be stored.
+		''' </summary>
+		''' <returns></returns>
+		''' <remarks>For internal Use only.</remarks>
+		Private ReadOnly Property SaveImages As Boolean
+			Get
+				Return OnURL_FileCreate_UserInteractions.SaveImages
+			End Get
+		End Property
+		''' =========================================================================================================
+		''' <summary>
+		''' Returns the directory to save the images to.
+		''' </summary>
+		''' <returns></returns>
+		'''     ''' <remarks>For internal Use only.</remarks>
+		Private ReadOnly Property ImageSaveDir As String
+			Get
+				Return OnURL_FileCreate_UserInteractions.ImgSaveDir
+			End Get
+		End Property
+#End Region
+
+#Region "---------------------------------------------------- Create URL Files --------------------------------------------------"
+
+		Public Class CreateUrlFileResult
+			Public Cancelled As Boolean = False
+			Public ImagesAdded As Integer = 0
+			Public ImagesTotal As Integer = 0
+			Public Filename As String
+
+			Sub New()
+			End Sub
+		End Class
+
+		''' =========================================================================================================
+		''' <summary>
+		''' This Method asks the User for a Blog-URL and Scrapes the Blog asynchronous.
+		''' </summary>
+		Public Function CreateURLFileAsync() As CreateUrlFileResult
+			Try
+				Return StartAllWorkAsync(URL_File_Tasks.CreateURLFile)
+			Catch
+				Throw
+			End Try
+		End Function
+
+		''' =========================================================================================================
+		''' <summary>
+		''' This Method Asks the User for a Blog-URL and Scrapes the Blog.
+		''' </summary>
+		''' <param name="___ImageBlogUrl">Optional. The URL for Imageblog to scrape from. If empty it will prompt for it.</param>
+		''' <remarks>This Function is prepared to use with a Backgroundworker. 
+		''' <return>Returns an <see cref="CreateUrlFileResult">CreateUrlFileResult-Object</see>/>.</return>
+		''' Improvements :
+		''' - Fixed all CrossthreadCalls, wich caused the System not to work, with UserInteraction.
+		''' - Removed all hard-coded Folder and File Strings.
+		''' - Removed redundant Code.
+		''' - If you review and downloaded images, the image was downloaded twice.
+		''' - The Blog-XML was downloaded with XML-Doc. After you scrapted an URL, you sometimes couldn't scrape it again.
+		''' - Deadlinks were imported again.
+		''' - Adding an URL to DislikeList was only writing to File, so a disliked URL could get into File, 
+		'''   if a Blog Contains it twice.
+		''' </remarks>
+		Private Function BlogToUrlFile(ByVal Optional ___ImageBlogUrl As String = "") As CreateUrlFileResult
+			Try
+				'===============================================================================
+				' Declaration of Variables
+				'===============================================================================
+				Me.URL_FileCreate_OnProgressChanged(0, 0, 0, WorkingStages.Started, Nothing)
+				If Me.CancellationPending = True Then Return Nothing
+				Dim ___ExactPostsCount As Integer = -1 ' If its -1, then the First Pass has not been done
+				Dim ___RoundPostsCount As Integer = -1
+				Dim ___ImageCountAdded As Integer = 0
+				Dim ___ImageCountTotal As Integer = 0
+				Dim ___BlogCycle As Integer = 0
+				Dim ___BlogCycleSize As Integer = 50
+
+				Dim ___BlogListOld, ___BlogListNew, ___DislikeList As New List(Of String)
+
+				If ___ImageBlogUrl = "" Then ___ImageBlogUrl = InputBox("Enter an image blog", "URL File Generator", "http://(Blog Name).tumblr.com/")
+				If ___ImageBlogUrl = "" Then Me.CancelAsync() : Return New CreateUrlFileResult With {.Cancelled = True}
+
+				Dim ___req As HttpWebRequest
+				Dim ___res As HttpWebResponse
+
+				Dim ___TempImg As Bitmap = Nothing
+				'===============================================================================
+				' Connection Try
+				'===============================================================================
+				___req = WebRequest.Create(___ImageBlogUrl)
+				___req.ReadWriteTimeout = 60000
+				___res = ___req.GetResponse()
+				___req.Abort()
+				'===============================================================================
+				' Convert URL For Local Filesystem
+				'===============================================================================
+				Dim ___ModifiedUrl As String
+				___ModifiedUrl = ___ImageBlogUrl
+				___ModifiedUrl = ___ModifiedUrl.Replace("http://", "")
+				___ModifiedUrl = ___ModifiedUrl.Replace("/", "")
+
+				Dim ___ImageURLPath As String = _ImageURLFileDir & ___ModifiedUrl & ".txt"
+				'===============================================================================
+				' Load the old File if possible, to avoid Duplicate Files
+				'===============================================================================
+				If File.Exists(___ImageURLPath) Then
+					' ReadFile
+					Using __UrlFileReader As New StreamReader(___ImageURLPath)
+						Try
+							While __UrlFileReader.Peek <> -1
+								___BlogListOld.Add(__UrlFileReader.ReadLine)
+							End While
+						Catch
+							Throw
+						Finally
+							__UrlFileReader.Close()
+						End Try
+					End Using
+				End If
+				'===============================================================================
+				'                           Load Dislike List. 
+				'===============================================================================
+				If File.Exists(_DislikeListPath) Then
+					Using __DislikeFileReader As New StreamReader(_DislikeListPath)
+						Try
+							While __DislikeFileReader.Peek <> -1
+								___DislikeList.Add(__DislikeFileReader.ReadLine())
+							End While
+						Catch
+							Throw
+						Finally
+							__DislikeFileReader.Close()
+						End Try
+					End Using
+				End If
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+				'                         Start Page-Scraping
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+Scrape:
+				' >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> Cancel <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+				If Me.CancellationPending AndAlso ___ExactPostsCount = -1 Then Return New CreateUrlFileResult With {.Cancelled = True}
+				If Me.CancellationPending Then GoTo ExitScrape
+				'===============================================================================
+				'                      Download Single-XML-Blog-Page
+				'===============================================================================
+				Dim ___doc As XmlDocument = New XmlDocument()
+
+				___ImageBlogUrl = ___ImageBlogUrl.Replace("/", "")
+				___ImageBlogUrl = ___ImageBlogUrl.Replace("http:", "http://")
+				Debug.Print("ImageBlogURL = " & ___ImageBlogUrl)
+
+				___req = WebRequest.Create(___ImageBlogUrl & "/api/read?start=" & ___BlogCycle & "&num=50")
+				___res = ___req.GetResponse()
+
+				Dim Reader As New XmlTextReader(___res.GetResponseStream)
+				___doc.Load(Reader)
+				___req.Abort() ' You need to do this, otherwise you cant't run it a seccond time on the same URL that session!
+				___res.Close()
+				'===============================================================================
+				'                         Read Total Blog-Posts
+				'===============================================================================
+				If ___ExactPostsCount = -1 Then
+					Try
+						For Each node As XmlNode In ___doc.DocumentElement.SelectNodes("//posts")
+							___ExactPostsCount = CInt(node.Attributes.ItemOf("total").InnerText)
+							___RoundPostsCount = RoundUpToNearest(___ExactPostsCount, 50)
+
+							Debug.Print("Round-PostsCount = " & ___RoundPostsCount)
+						Next
+					Catch
+						Throw New Exception("Unable to read site api!!")
+					End Try
+				End If
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+				'                             Blog-Loop-Start 
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+				For Each ___PhotoNode As XmlNode In ___doc.DocumentElement.SelectNodes("//photo-url")
+					Application.DoEvents()
+					' >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> Cancel <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+					If Me.CancellationPending Then GoTo ExitScrape
+					If CInt(___PhotoNode.Attributes.ItemOf("max-width").InnerText) = 1280 Then
+
+						Me.URL_FileCreate_OnProgressChanged(___ImageCountTotal, ___BlogCycle / ___BlogCycleSize, ___RoundPostsCount / ___BlogCycleSize, WorkingStages.Blog_Scraping, Nothing)
+						'===============================================================================
+						'                         Check what to do with URL
+						'===============================================================================
+						If ___DislikeList.Contains(___PhotoNode.InnerXml) Or ___BlogListNew.Contains(___PhotoNode.InnerXml) Then
+							'############################ ALL - Disliked & Added #############################
+							' Always Skip Disliked Urls and already added URLs.
+							GoTo NextImage
+						ElseIf Me._Work = URL_File_Tasks.RebuildURLFiles AndAlso ___BlogListOld.Contains(___PhotoNode.InnerXml) Then
+							'########################### URL-Rebuild - Known URL #############################
+							' If rebuilding URL-File, only add files which were known before.
+							___BlogListNew.Add(___PhotoNode.InnerXml)           ' Add to new list
+							___ImageCountTotal += 1                             ' Increment Image Counter.
+							GoTo NextImage                                      ' No Saving or Reviewing    
+						ElseIf Me._Work = URL_File_Tasks.RebuildURLFiles
+							'########################## URL-Rebuild - Unknown URL ############################
+							' If Rebuilding URL-File skip Urls not previous known.
+							GoTo NextImage
+						ElseIf ___BlogListOld.Contains(___PhotoNode.InnerXml)
+							'########################## Create/Refresh - Known URL ###########################
+							___BlogListNew.Add(___PhotoNode.InnerXml)           ' Add to new list
+							___ImageCountTotal += 1                             ' Increment Image Counter.
+							GoTo NextImage                                      ' No Saving or Reviewing    
+						End If
+						'===============================================================================
+						'                                 Review Image
+						'===============================================================================
+						If ReviewImages = True Then
+							' Downlaod Image
+							___TempImg = New Bitmap(New IO.MemoryStream(New WebClient().DownloadData(___PhotoNode.InnerXml)))
+
+							Me.URL_FileCreate_OnProgressChanged(___ImageCountTotal, ___BlogCycle, ___RoundPostsCount, WorkingStages.ImageApproval, ___TempImg)
+
+							' Wait For User Approval
+							Do
+								Application.DoEvents()
+								' >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> Cancel <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+								If Me.CancellationPending Then GoTo ExitScrape
+							Loop Until ApproveImage <> ImageApprovalStatus.Pending
+
+							' If Img declined and DislikeFile is set, write URL to DislikeFile
+							If ApproveImage = ImageApprovalStatus.Declined _
+					And _DislikeListPath <> String.Empty Then
+								' Add the URL to DislikeList
+								___DislikeList.Add(___PhotoNode.InnerXml)
+								' If DislikeFile exists: Append URL Else create new File
+								If File.Exists(_DislikeListPath) Then
+									My.Computer.FileSystem.WriteAllText(_DislikeListPath, Environment.NewLine & ___PhotoNode.InnerXml, True)
+								Else
+									My.Computer.FileSystem.WriteAllText(_DislikeListPath, ___PhotoNode.InnerXml, True)
+								End If
+							End If
+						End If
+
+						'===============================================================================
+						'                                 Image Approved
+						'===============================================================================
+						If ApproveImage = ImageApprovalStatus.Approved Or ReviewImages = False Then
+							Try
+								' --------------------------SAVE IMAGE TO DISK --------------------------
+								If SaveImages = True Then
+									Dim ___XMLImagePath As String = ___PhotoNode.InnerXml
+
+									Dim ___DirSplit As String() = ___XMLImagePath.Split("/")
+									___XMLImagePath = ___DirSplit(___DirSplit.Length - 1)
+
+									Dim imgDir As String = ImageSaveDir
+									If Not File.Exists(imgDir & "\" & ___XMLImagePath.Replace("\\", "\")) Then
+										' Downloaded Picture already for Review?
+										If ___TempImg IsNot Nothing Then
+											' YES: Save it from Stream
+											___TempImg.Save(imgDir & "\" & ___XMLImagePath.Replace("\\", "\"))
+										Else
+											' NO: Go download it.
+											My.Computer.Network.DownloadFile(___PhotoNode.InnerXml, imgDir & "\" & ___XMLImagePath.Replace("\\", "\"))
+										End If
+									End If
+								End If
+								' -------------------------- ADD IMAGE TO LIST --------------------------
+								___BlogListNew.Add(___PhotoNode.InnerXml)
+								___ImageCountTotal += 1
+								___ImageCountAdded += 1
+							Catch ex As Exception
+								GoTo ExitScrape
+							End Try
+
+						End If
+NextImage:
+					End If
+					___TempImg = Nothing ' Reset Image
+				Next
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+				'             Blog-Loop-END 
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+				___BlogCycle += ___BlogCycleSize
+				If ___BlogCycle < ___RoundPostsCount And Not Me.CancellationPending Then GoTo Scrape
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+				'         Blog-Page-Scraping-END
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+				' Alternate ImageCounting on URL-FileRebuild.
+				If Me._Work = URL_File_Tasks.RebuildURLFiles Then ___ImageCountAdded = ___BlogListOld.Count - ___BlogListNew.Count
+ExitScrape:
+				Me.URL_FileCreate_OnProgressChanged(___ImageCountTotal, ___BlogCycle / ___BlogCycleSize, ___RoundPostsCount / ___BlogCycleSize, WorkingStages.Writing_File, Nothing)
+
+				' IF:   Work is Cancelled?
+				' Then: Write Combined New and Old List
+				' Else: Write only New List. This removes Dead links.
+				Dim ___BlogListCombine As New List(Of String)
+				If Me.CancellationPending = True _
+		Then ___BlogListCombine = ___BlogListOld.Union(___BlogListNew).ToList _
+		Else ___BlogListCombine = ___BlogListNew
+				'===============================================================================
+				' Delete old URL-File: Retry delayed 10 times if the File is blocked by use.
+				'===============================================================================
+				Dim ___retryCounter As Integer = 0
+RetryDeleteFile:
+				Try
+					If File.Exists(___ImageURLPath) Then My.Computer.FileSystem.DeleteFile(___ImageURLPath)
+				Catch ex As IO.IOException
+					'@@@@@@@@@@@@@@@@@@@@@@@@ IO.Exception @@@@@@@@@@@@@@@@@@@@@@@@
+					___retryCounter += 1
+					If ___retryCounter > 10 Then
+						' Wait and try again.
+						Threading.Thread.Sleep(500)
+						GoTo RetryDeleteFile
+					Else
+						' Tried enough -> cancel action.
+						Throw
+					End If
+				End Try
+				'===============================================================================
+				' Write the new URL-File -> Join Lines with Newline together.
+				'===============================================================================
+				File.WriteAllText(___ImageURLPath, String.Join(vbCrLf, ___BlogListCombine))
+
+
+				___doc = Nothing
+				___req = Nothing
+				___res = Nothing
+
+				Me.URL_FileCreate_OnProgressChanged(0, 0, 0, WorkingStages.Completed, Nothing)
+
+				Return New CreateUrlFileResult With {.Cancelled = Me.CancellationPending,
+												.Filename = ___ModifiedUrl,
+												.ImagesAdded = ___ImageCountAdded,
+												.ImagesTotal = ___ImageCountTotal
+											}
+			Catch ex As Exception
+				'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+				'                                            All Errors
+				'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+				Throw
+			End Try
+		End Function
+
+#End Region
+
+#Region "-------------------------------------------------- Maintain URL Files --------------------------------------------------"
+
+		Public Class MaintainUrlResult
+			''' <summary>
+			''' The number of removed/added Links
+			''' </summary>
+			Public ModifiedLinkCount As Integer = 0
+			''' <summary>
+			''' The Number of all Processed URLs.
+			''' </summary>
+			Public LinkCountTotal As Integer = 0
+			''' <summary>
+			''' The maintained URL-Filenames without extension.
+			''' </summary>
+			Public MaintainedUrlFiles As New List(Of String)
+			''' <summary>
+			''' If an Error occurs, while processing an URL-File, the ErrorMessage will added here.
+			''' </summary>
+			Public ErrorText As New List(Of String)
+			Public Cancelled As Boolean = False
+
+			Sub New()
+			End Sub
+		End Class
+
+		''' =========================================================================================================
+		''' <summary>
+		''' Checks all URls in the URL-File-Folder. No new URLs will be added, dead one removed
+		''' </summary>
+		''' <returns>Returns an Object of <see cref="MaintainUrlResult">MaintainUrlResult</see>/>.</returns>
+		Public Function RebuildURLFilesAsync() As MaintainUrlResult
+			Try
+				Return StartAllWorkAsync(URL_File_Tasks.RebuildURLFiles)
+			Catch
+				Throw
+			End Try
+		End Function
+
+		''' =========================================================================================================
+		''' <summary>
+		''' Refreshes all URL-Files and automatically adds new URLs. If not Cancelled, it will remove Dead-URLs.
+		''' </summary>
+		''' <returns>Returns an Object of <see cref="MaintainUrlResult">MaintainUrlResult</see>/>.</returns>
+		Public Function RefreshURLFilesAsync() As MaintainUrlResult
+			Try
+				Return StartAllWorkAsync(URL_File_Tasks.RefreshURLFiles)
+			Catch
+				Throw
+			End Try
+		End Function
+
+		''' =========================================================================================================
+		''' <summary>
+		''' Function for Maintaining URL-Files. Basicly it loops through the Folder and gives UI-Feedback.
+		''' </summary>
+		''' <returns></returns>
+		Private Function MaintainURLFiles() As MaintainUrlResult
+			Dim ___rtnResult As New MaintainUrlResult
+			With ___rtnResult
+				Try
+					Me._OverallProgress = 0
+					Me._OverallProgressTotal = 0
+					Me._InfoText = String.Empty
+
+
+					' Get all TxtFiles in specified Folder 
+					.MaintainedUrlFiles.AddRange(My.Computer.FileSystem.GetFiles(Me._ImageURLFileDir, FileIO.SearchOption.SearchTopLevelOnly, "*.txt"))
+					For i = 0 To .MaintainedUrlFiles.Count - 1
+						' Extract Name and set Infotext, for UI and Debug
+						Dim ___tmpFileName As String = Path.GetFileName(.MaintainedUrlFiles(i)).Replace(".txt", "")
+						Try
+							Me._InfoText = If(Me._Work = URL_File_Tasks.RefreshURLFiles, "Refreshing: ", "Rebuilding: ") & ___tmpFileName
+
+							Dim tmpresult As CreateUrlFileResult = BlogToUrlFile("http://" & ___tmpFileName)
+							'>>>>>>>>>>>>>>>>>>>>>>>> Cancellation <<<<<<<<<<<<<<<<<<<<<<<<<
+							If tmpresult.Cancelled = True And tmpresult.Filename = String.Empty Then Exit Try
+							' Set the Clear FileName 
+							.MaintainedUrlFiles(i) = tmpresult.Filename
+
+							' Set the Values for returning to UI
+							Me._OverallProgress = i
+							Me._OverallProgressTotal = .MaintainedUrlFiles.Count
+
+							' Calculate Totals
+							.ModifiedLinkCount += tmpresult.ImagesAdded
+							.LinkCountTotal += tmpresult.ImagesTotal
+						Catch ex As Exception When Me.CancellationPending
+							'>>>>>>>>>>>>>>>>>>>>>>>> Cancellation <<<<<<<<<<<<<<<<<<<<<<<<<
+							' On Cancellation an ArgumentOutOfBla Exc. Occurs.
+							If Me.CancellationPending Then Return ___rtnResult
+						Catch ex As Exception
+							'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨  All Errors  ▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+							.MaintainedUrlFiles(i) = ___tmpFileName
+							___rtnResult.ErrorText.Add(String.Format("Error {0} URL-File '{1}': {2}",
+																If(Me._Work = URL_File_Tasks.RefreshURLFiles, "refreshing", "rebuilding"),
+																___tmpFileName,
+																ex.Message))
+						End Try
+						'>>>>>>>>>>>>>>>>>>>>>>>> Cancellation <<<<<<<<<<<<<<<<<<<<<<<<<
+						If Me.CancellationPending Then Exit For
+					Next
+
+					Return ___rtnResult
+				Catch ex As Exception
+					'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+					'                                            All Errors
+					'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+					Throw
+				Finally
+					'⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑ Finally ⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑
+					If Me.CancellationPending Then
+						.Cancelled = True
+						.MaintainedUrlFiles.RemoveAll(Function(x) x <> Path.GetFileName(x).Replace(".txt", ""))
+						.MaintainedUrlFiles.Capacity = .MaintainedUrlFiles.Count
+					End If
+				End Try
+			End With
+
+		End Function
+
+#End Region
+
+#Region "-------------------------------------------------- Misc. Functions ---------------------------------------------------"
+
+		''' =========================================================================================================
+		''' <summary>
+		''' Starts the overgiven Work.
+		''' </summary>
+		''' <param name="WorkToStart">The task to Start.</param>
+		''' <returns></returns>
+		Private Function StartAllWorkAsync(ByVal WorkToStart As URL_File_Tasks) As Object
+			Try
+				Me._Work = WorkToStart
+				Me.RunWorkerAsync()
+
+				Do Until Me.IsBusy = False
+					Application.DoEvents()
+				Loop
+
+				If _BGW_Result.Error IsNot Nothing Then Throw _BGW_Result.Error
+				If _BGW_Result.Cancelled = True Then Throw New DivideByZeroException("Action was cancelled.")
+				Return _BGW_Result.Result
+			Catch
+				Throw
+			Finally
+				Me._Work = URL_File_Tasks.Idle
+			End Try
+		End Function
+
+		Private Function RoundUpToNearest(Value As Integer, nearest As Integer) As Integer
+			Return CInt(Math.Ceiling(Value / nearest) * nearest)
+		End Function
+
+#End Region
+
+	End Class
+
+End Namespace

--- a/Tease AI/Form2.Designer.vb
+++ b/Tease AI/Form2.Designer.vb
@@ -996,10 +996,8 @@ Partial Class FrmSettings
 		Me.OpenScriptDialog = New System.Windows.Forms.OpenFileDialog()
 		Me.OpenSettingsDialog = New System.Windows.Forms.OpenFileDialog()
 		Me.SaveSettingsDialog = New System.Windows.Forms.SaveFileDialog()
-		Me.BWRebuildURLFiles = New System.ComponentModel.BackgroundWorker()
-		Me.BWRefreshURLFiles = New System.ComponentModel.BackgroundWorker()
+		Me.BWURLFiles = New Tease_AI.URL_Files.URL_File_BGW
 		Me.BWValidateLocalFiles = New System.ComponentModel.BackgroundWorker()
-		Me.BWCreateURLFiles = New System.ComponentModel.BackgroundWorker()
 		Me.TTDir = New System.Windows.Forms.ToolTip(Me.components)
 		Me.GroupBox65 = New System.Windows.Forms.GroupBox()
 		Me.Label136 = New System.Windows.Forms.Label()
@@ -12837,21 +12835,13 @@ Partial Class FrmSettings
 		Me.SaveSettingsDialog.Filter = "TXT Files (*.txt)|*.txt"
 		Me.SaveSettingsDialog.Title = "Select a location to save current Domme settings"
 		'
-		'BWRebuildURLFiles
-		'
-		Me.BWRebuildURLFiles.WorkerReportsProgress = True
-		Me.BWRebuildURLFiles.WorkerSupportsCancellation = True
-		'
-		'BWRefreshURLFiles
-		'
-		Me.BWRefreshURLFiles.WorkerReportsProgress = True
-		Me.BWRefreshURLFiles.WorkerSupportsCancellation = True
-		'
 		'BWValidateLocalFiles
 		'
 		'
-		'BWCreateURLFiles
+		'BWRefreshURLFiles
 		'
+		Me.BWURLFiles.WorkerReportsProgress = True
+		Me.BWURLFiles.WorkerSupportsCancellation = True
 		'
 		'GroupBox65
 		'
@@ -14079,16 +14069,13 @@ Partial Class FrmSettings
 	Friend WithEvents PBMaintenance As System.Windows.Forms.ProgressBar
 	Friend WithEvents LBLMaintenance As System.Windows.Forms.Label
 	Friend WithEvents BTNMaintenanceRebuild As System.Windows.Forms.Button
-	Friend WithEvents BWRebuildURLFiles As System.ComponentModel.BackgroundWorker
 	Friend WithEvents BTNMaintenanceCancel As System.Windows.Forms.Button
 	Friend WithEvents Label116 As System.Windows.Forms.Label
 	Friend WithEvents PBCurrent As System.Windows.Forms.ProgressBar
 	Friend WithEvents Label117 As System.Windows.Forms.Label
-	Friend WithEvents BWRefreshURLFiles As System.ComponentModel.BackgroundWorker
 	Friend WithEvents BTNMaintenanceRefresh As System.Windows.Forms.Button
 	Friend WithEvents BTNMaintenanceValidate As System.Windows.Forms.Button
 	Friend WithEvents BWValidateLocalFiles As System.ComponentModel.BackgroundWorker
-	Friend WithEvents BWCreateURLFiles As System.ComponentModel.BackgroundWorker
 	Friend WithEvents TabPage27 As System.Windows.Forms.TabPage
 	Friend WithEvents BTNMaintenanceScripts As System.Windows.Forms.Button
 	Friend WithEvents Button3 As System.Windows.Forms.Button
@@ -14263,4 +14250,5 @@ Partial Class FrmSettings
 	Friend WithEvents CheckBox1 As System.Windows.Forms.CheckBox
 	Friend WithEvents Label135 As System.Windows.Forms.Label
 	Friend WithEvents TrackBar2 As System.Windows.Forms.TrackBar
+	Friend WithEvents BWURLFiles As Tease_AI.URL_Files.URL_File_BGW
 End Class

--- a/Tease AI/Form2.resx
+++ b/Tease AI/Form2.resx
@@ -1598,42 +1598,33 @@ to give people a chance to try it out and suggest new features before finalizing
 </value>
   </data>
   <metadata name="OpenFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>133, 17</value>
   </metadata>
   <metadata name="GetColor.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>159, 17</value>
+    <value>275, 17</value>
   </metadata>
   <metadata name="FolderBrowserDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>259, 17</value>
+    <value>375, 17</value>
   </metadata>
   <metadata name="WebImageFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>430, 17</value>
+    <value>546, 17</value>
   </metadata>
   <metadata name="SaveFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>595, 17</value>
+    <value>711, 17</value>
   </metadata>
   <metadata name="OpenScriptDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>732, 17</value>
+    <value>848, 17</value>
   </metadata>
   <metadata name="OpenSettingsDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>880, 17</value>
+    <value>996, 17</value>
   </metadata>
   <metadata name="SaveSettingsDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1041, 17</value>
-  </metadata>
-  <metadata name="BWRebuildURLFiles.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1197, 17</value>
-  </metadata>
-  <metadata name="BWRefreshURLFiles.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1329, 17</value>
+    <value>1157, 17</value>
   </metadata>
   <metadata name="BWValidateLocalFiles.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 56</value>
   </metadata>
-  <metadata name="BWCreateURLFiles.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>183, 56</value>
-  </metadata>
   <metadata name="TTDir.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>334, 56</value>
+    <value>183, 56</value>
   </metadata>
 </root>

--- a/Tease AI/Form2.vb
+++ b/Tease AI/Form2.vb
@@ -8,7 +8,7 @@ Imports System.Speech.Synthesis
 Imports System.Net
 Imports System.Text
 Imports System.Threading
-
+Imports Tease_AI.URL_Files
 
 
 
@@ -40,10 +40,6 @@ Public Class FrmSettings
 	'Dim Fringe As New SpeechSynthesizer
 
 	Private Thr As Threading.Thread
-
-	Dim URLCancel As Boolean
-
-	Dim CancelRebuild As Boolean
 
 	Dim TagImageFolder As String
 
@@ -2270,656 +2266,260 @@ trypreviousimage:
 
 	End Sub
 
-	Private Sub Button38_Click(sender As System.Object, e As System.EventArgs) Handles BTNWICreateURL.Click
-
-
-		BWCreateURLFiles.RunWorkerAsync()
-
-	End Sub
-
-
-	Public Sub CreateURLFiles()
-
-		Dim FirstPass As Boolean = False
-		Dim ExactPostsCount As Integer
-		Dim PostsInt As Integer = 0
-		Dim ImageAdded As Boolean
-		Dim BlogCycle As Integer
-		BlogCycle = -50
-
-		Dim BlogListOld As New List(Of String)
-		Dim BlogListNew As New List(Of String)
-
-		WebImageProgressBar.Value = 0
-		WebImageProgressBar.Maximum = 2500
-
-		Dim ImageBlogUrl As String = InputBox("Enter an image blog", "URL File Generator", "http://(Blog Name).tumblr.com/")
-		If ImageBlogUrl = "" Then Return
-
-		Dim req As System.Net.WebRequest
-		Dim res As System.Net.WebResponse
-
+	Private Sub Button38_Click(sender As System.Object, e As System.EventArgs) Handles BTNWICreateURL.Click,
+																					   BTNMaintenanceRefresh.Click,
+																					   BTNMaintenanceRebuild.Click
+        ' Group Buttons by inital-State.
+        Dim __PreEnabled As New List(Of Control) From
+			{BTNWIOpenURL, BTNWICreateURL, BTNMaintenanceRefresh,
+			BTNMaintenanceRebuild, BTNMaintenanceScripts, BTNMaintenanceValidate}
+		Dim __PreDisabled As New List(Of Control) From
+			{BTNWICancel, BTNMaintenanceCancel}
 
 		Try
-			req = System.Net.WebRequest.Create(ImageBlogUrl)
-			res = req.GetResponse()
-		Catch
-			MessageBox.Show(Me, "This does not appear to be a valid URL!", "Error!", MessageBoxButtons.OK, MessageBoxIcon.Hand)
-			Return
-		End Try
+            ' Set their new State, so the User can't disturb.
+            __PreEnabled.ForEach(Sub(x) x.Enabled = False)
+			__PreDisabled.ForEach(Sub(x) x.Enabled = True)
 
-		Dim ModifiedUrl As String
-		ModifiedUrl = ImageBlogUrl
-		ModifiedUrl = ModifiedUrl.Replace("http://", "")
-		ModifiedUrl = ModifiedUrl.Replace("/", "")
-
-		Dim ImageURLPath As String = Application.StartupPath & "\Images\System\URL Files\" & ModifiedUrl & ".txt"
-
-		If File.Exists(ImageURLPath) Then
-			Dim URLReader As New StreamReader(ImageURLPath)
-			While URLReader.Peek <> -1
-				BlogListOld.Add(URLReader.ReadLine)
-			End While
-
-			URLReader.Close()
-			URLReader.Dispose()
-
-
-
-		End If
-
-
-		LBLWebImageCount.Text = "0/0"
-
-
-		Dim DupeList As New List(Of String)
-		DupeList.Clear()
-
-		Dim DislikeList As New List(Of String)
-		DislikeList.Clear()
-
-
-		If File.Exists(ImageURLPath) Then
-			Dim DupeCheck As New StreamReader(ImageURLPath)
-
-			While DupeCheck.Peek <> -1
-				DupeList.Add(DupeCheck.ReadLine())
-			End While
-
-			DupeCheck.Close()
-			DupeCheck.Dispose()
-
-		End If
-
-		If File.Exists(Application.StartupPath & "\Images\System\DislikedImageURLs.txt") Then
-			Dim DislikeCheck As New StreamReader(Application.StartupPath & "\Images\System\DislikedImageURLs.txt")
-
-			While DislikeCheck.Peek <> -1
-				DislikeList.Add(DislikeCheck.ReadLine())
-			End While
-
-			DislikeCheck.Close()
-			DislikeCheck.Dispose()
-
-		End If
-
-Scrape:
-
-		BTNWIContinue.Enabled = True
-		BTNWIAddandContinue.Enabled = True
-		BTNWICancel.Enabled = True
-		BTNWICreateURL.Enabled = False
-		BTNWIOpenURL.Enabled = False
-
-		BTNWINext.Enabled = False
-		BTNWIPrevious.Enabled = False
-		BTNWIRemove.Enabled = False
-		BTNWILiked.Enabled = False
-		BTNWIDisliked.Enabled = False
-		BTNWISave.Enabled = False
-
-
-
-		ImageAdded = False
-
-		BlogCycle += 50
-
-
-
-		If URLCancel = True Then GoTo ExitScrape
-
-		Dim doc As XmlDocument = New XmlDocument()
-
-		Try
-			ImageBlogUrl = ImageBlogUrl.Replace("/", "")
-			ImageBlogUrl = ImageBlogUrl.Replace("http:", "http://")
-			Debug.Print("ImageBlogURL = " & ImageBlogUrl)
-			doc.Load(ImageBlogUrl & "/api/read?start=" & BlogCycle & "&num=50")
-		Catch ex As Exception
-		End Try
-
-		If FirstPass = False Then
-			Try
-				For Each node As XmlNode In doc.DocumentElement.SelectNodes("//posts")
-					Dim PostsCount As Integer = node.Attributes.ItemOf("total").InnerText
-					ExactPostsCount = PostsCount
-					PostsCount = RoundUpToNearest(PostsCount, 50)
-					WebImageProgressBar.Maximum = PostsCount
-					Debug.Print("PostsCount = " & PostsCount)
-				Next
-				FirstPass = True
-			Catch
-				MessageBox.Show(Me, "Unable to read site api!!", "Error!", MessageBoxButtons.OK, MessageBoxIcon.Hand)
-				BTNWIContinue.Enabled = False
-				BTNWIAddandContinue.Enabled = False
-				BTNWICancel.Enabled = False
-				BTNWICreateURL.Enabled = True
-				BTNWIOpenURL.Enabled = True
-				FirstPass = False
-				Return
-			End Try
-		End If
-
-		For Each node As XmlNode In doc.DocumentElement.SelectNodes("//photo-url")
-			Application.DoEvents()
-			If URLCancel = True Then GoTo ExitScrape
-			If node.Attributes.ItemOf("max-width").InnerText = 1280 Then
-				PostsInt += 1
-				LBLWebImageCount.Text = PostsInt & "/" & ExactPostsCount
-				ImageAdded = True
-
-				If DupeList.Contains(node.InnerXml) Or DislikeList.Contains(node.InnerXml) Or BlogListNew.Contains(node.InnerXml) Then
-					'MsgBox(node.InnerXml & " ALREADY HAS!")
-					If CBWISaveToDisk.Checked = False Then GoTo AlreadyHas
-				End If
-
-
-				If CBWIReview.Checked = True Then
-
+			Select Case sender.name
+				Case BTNWICreateURL.Name
+                    '**************************************************************************************************************
+                    '                                                Create URL-File
+                    '**************************************************************************************************************
+                    Dim __BtnLocalURL As New List(Of Control) From {
+						BTNWINext, BTNWIPrevious, BTNWIRemove, BTNWILiked, BTNWIDisliked, BTNWISave}
 					Try
-						WebPictureBox.Image.Dispose()
+                        ' Disable Buttons for Opening-URL-Files
+                        __BtnLocalURL.ForEach(Sub(x) x.Enabled = False)
+
+                        ' Run Backgroundworker
+                        Dim __tmpResult As String = DirectCast(BWURLFiles.CreateURLFileAsync(),
+															   URL_File_BGW.CreateUrlFileResult).Filename
+
+                        ' Activate the created URL-File
+                        URL_File_Set(__tmpResult)
+
+                        ' UserInfo
+                        MsgBox("URL File has been saved to:" &
+							   vbCrLf & vbCrLf & Application.StartupPath & "\Images\System\URL Files\" & __tmpResult & ".txt" &
+							   vbCrLf & vbCrLf & "Use the ""Open URL File"" button to load and view your collections.",  , "Success!")
 					Catch
+                        '▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+                        '                                            All Errors
+                        '▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+                        Throw
+					Finally
+                        '⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑ Finally ⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑
+                        __BtnLocalURL.ForEach(Sub(x) x.Enabled = True)
 					End Try
+				Case BTNMaintenanceRefresh.Name
+                    '**************************************************************************************************************
+                    '                                             Refresh URL-Files
+                    '**************************************************************************************************************
+                    Try
 
-					WebPictureBox.Image = Nothing
-					GC.Collect()
-					WebPictureBox.Image = New System.Drawing.Bitmap(New IO.MemoryStream(New System.Net.WebClient().DownloadData(node.InnerXml)))
+                        ' Run Backgroundworker
+                        Dim __tmpResult As URL_File_BGW.MaintainUrlResult = BWURLFiles.RefreshURLFilesAsync()
 
-					Do
-						Application.DoEvents()
-					Loop Until Form1.ApproveImage <> 0 Or URLCancel = True
+                        ' Activate the URL-Files
+                        __tmpResult.MaintainedUrlFiles.ForEach(AddressOf URL_File_Set)
 
-					If URLCancel = True Then GoTo ExitScrape
-
-					If Form1.ApproveImage = 2 Then
-
-						If File.Exists(Application.StartupPath & "\Images\System\DislikedImageURLs.txt") Then
-							My.Computer.FileSystem.WriteAllText(Application.StartupPath & "\Images\System\DislikedImageURLs.txt", Environment.NewLine & node.InnerXml, True)
+						If __tmpResult.Cancelled Then
+							MessageBox.Show(Me, "Refreshing URL-File has been aborted after " & __tmpResult.MaintainedUrlFiles.Count & " URL-Files." &
+											vbCrLf & __tmpResult.ModifiedLinkCount & " new URLs have been added.",
+											"Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
+						ElseIf __tmpResult.ErrorText.Capacity > 0
+							MessageBox.Show(Me, "URL Files have been refreshed with errors!" &
+											vbCrLf & vbCrLf & __tmpResult.ModifiedLinkCount & " new URLs have been added." &
+											vbCrLf & vbCrLf & __tmpResult.LinkCountTotal & " URLs in total." &
+											vbCrLf & vbCrLf & String.Join(vbCrLf, __tmpResult.ErrorText),
+											"Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
 						Else
-							My.Computer.FileSystem.WriteAllText(Application.StartupPath & "\Images\System\DislikedImageURLs.txt", node.InnerXml, True)
+							MessageBox.Show(Me, "All URL Files have been refreshed!" &
+											vbCrLf & vbCrLf & __tmpResult.ModifiedLinkCount & " new URLs have been added." &
+											vbCrLf & vbCrLf & __tmpResult.LinkCountTotal & " URLs in total.",
+											"Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
 						End If
-
-					End If
-
-
-				Else
-
-					Form1.ApproveImage = 1
-
-				End If
-
-				Debug.Print("ApproveImage = " & Form1.ApproveImage)
-
-				If Form1.ApproveImage = 1 Then
-					Try
-						If CBWISaveToDisk.Checked = True Then
-							Dim XMLImagePath As String = node.InnerXml
-
-							Dim DirSplit As String() = XMLImagePath.Split("/")
-							XMLImagePath = DirSplit(DirSplit.Length - 1)
-
-							' ### Clean Code
-							'Do Until Not XMLImagePath.Contains("/")
-							'XMLImagePath = XMLImagePath.Remove(0, 1)
-							'Loop
-							Debug.Print("TBWIDirectory.Text & XMLImagePath = " & TBWIDirectory.Text & "\" & XMLImagePath.Replace("\\", "\"))
-							If Not File.Exists(TBWIDirectory.Text & "\" & XMLImagePath.Replace("\\", "\")) Then
-								My.Computer.Network.DownloadFile(node.InnerXml, TBWIDirectory.Text & "\" & XMLImagePath.Replace("\\", "\"))
-							End If
-						End If
-
-						BlogListNew.Add(node.InnerXml)
-
-
-						'If File.Exists(ImageURLPath) Then
-						'My.Computer.FileSystem.WriteAllText(ImageURLPath, Environment.NewLine & node.InnerXml, True)
-						'Else
-						'My.Computer.FileSystem.WriteAllText(ImageURLPath, node.InnerXml, True)
-						'End If
-
 					Catch
-						GoTo ExitScrape
-					End Try
-
-				End If
-
-AlreadyHas:
-
-				Form1.ApproveImage = 0
-
-			End If
-
-		Next
-
-		WebImageProgressBar.Value = WebImageProgressBar.Value + 50
-
-		If ImageAdded = True And WebImageProgressBar.Value < WebImageProgressBar.Maximum Then GoTo Scrape
-
-ExitScrape:
-
-		URLCancel = False
-
-		BTNWIContinue.Enabled = False
-		BTNWIAddandContinue.Enabled = False
-		BTNWICancel.Enabled = False
-
-
-		WebPictureBox.Image = Nothing
-		LBLWebImageCount.Text = ExactPostsCount & "/" & ExactPostsCount
-
-		If File.Exists(ImageURLPath) Then My.Computer.FileSystem.DeleteFile(ImageURLPath)
-
-		Dim BlogCombine As New List(Of String)
-
-		For i As Integer = 0 To BlogListNew.Count - 1
-			BlogCombine.Add(BlogListNew(i))
-			Debug.Print("BLN " & i & ": " & BlogListNew(i))
-		Next
-
-		If BlogListOld.Count > 0 Then
-			Debug.Print(BlogListOld.Count)
-			For i As Integer = 0 To BlogListOld.Count - 1
-				BlogCombine.Add(BlogListOld(i))
-				Debug.Print("BLO " & i & ": " & BlogListOld(i))
-			Next
-
-		End If
-
-		Dim fs As New FileStream(ImageURLPath, FileMode.Create)
-		Dim sw As New StreamWriter(fs)
-		For i As Integer = 0 To BlogCombine.Count - 1
-			If i <> BlogCombine.Count - 1 Then
-				sw.WriteLine(BlogCombine(i))
-			Else
-				sw.Write(BlogCombine(i))
-			End If
-		Next
-		sw.Close()
-		sw.Dispose()
-		fs.Close()
-		fs.Dispose()
-
-		MsgBox("URL File has been saved to:" & Environment.NewLine & Environment.NewLine & Application.StartupPath & "\Images\System\URL Files\" & ModifiedUrl & ".txt" & Environment.NewLine & Environment.NewLine & "Use the ""Open URL File"" button to load and view your collections.", , "Success!")
-
-		If Not URLFileList.Items.Contains(ModifiedUrl) Then
-			URLFileList.Items.Add(ModifiedUrl)
-			For i As Integer = 0 To URLFileList.Items.Count - 1
-				If URLFileList.Items(i) = ModifiedUrl Then URLFileList.SetItemChecked(i, True)
-			Next
-		End If
-
-		Dim FileStream As New System.IO.FileStream(Application.StartupPath & "\Images\System\URLFileCheckList.cld", IO.FileMode.Create)
-		Dim BinaryWriter As New System.IO.BinaryWriter(FileStream)
-		For i = 0 To URLFileList.Items.Count - 1
-			BinaryWriter.Write(CStr(URLFileList.Items(i)))
-			BinaryWriter.Write(CBool(URLFileList.GetItemChecked(i)))
-		Next
-		BinaryWriter.Close()
-		FileStream.Dispose()
-
-		WebImageProgressBar.Value = 0
-		WebImageProgressBar.Maximum = 2500
-		LBLWebImageCount.Text = "0/0"
-		BTNWICreateURL.Enabled = True
-		BTNWIOpenURL.Enabled = True
-		FirstPass = False
-
-	End Sub
-
-
-	Public Sub CombineURLFiles()
-
-		Dim NewURLCount As Integer
-		Dim TotalURLCount As Integer
-
-		Dim MaintString As System.Collections.ObjectModel.ReadOnlyCollection(Of String)
-		MaintString = My.Computer.FileSystem.GetFiles(Application.StartupPath & "\Images\System\URL Files")
-
-		Dim MaintCount As Integer = CStr(MaintString.Count)
-		PBMaintenance.Maximum = MaintCount
-		PBMaintenance.Value = 0
-
-		For Each foundFile As String In My.Computer.FileSystem.GetFiles(Application.StartupPath & "\Images\System\URL Files\", FileIO.SearchOption.SearchTopLevelOnly, "*.txt")
-
-			If CancelRebuild = True Then
-				PBMaintenance.Value = 0
-				PBCurrent.Value = 0
-				LBLMaintenance.Text = ""
-				CancelRebuild = False
-				BTNMaintenanceRebuild.Enabled = True
-				BTNMaintenanceCancel.Enabled = False
-				BTNMaintenanceRefresh.Enabled = True
-				BTNMaintenanceValidate.Enabled = True
-				Return
-			End If
-
-			Debug.Print("FoundFile = " & foundFile)
-
-			Dim FirstPass As Boolean = False
-			Dim ExactPostsCount As Integer
-			Dim PostsInt As Integer = 0
-			Dim ImageAdded As Boolean
-			Dim BlogCycle As Integer
-			BlogCycle = -50
-
-			NewURLCount = 0
-
-			Dim BlogListOld As New List(Of String)
-			Dim BlogListNew As New List(Of String)
-
-			Dim ImageBlogUrl As String = foundFile.Replace(Application.StartupPath & "\Images\System\URL Files\", "")
-			Dim BlogUrlInfo As String = ImageBlogUrl
-
-			ImageBlogUrl = ImageBlogUrl.Replace(".txt", "")
-			ImageBlogUrl = "http://" & ImageBlogUrl
-
-			LBLMaintenance.Text = "Checking " & BlogUrlInfo & "..."
-
-			Dim req As System.Net.WebRequest
-			Dim res As System.Net.WebResponse
-
-			req = System.Net.WebRequest.Create(ImageBlogUrl)
-
-			Try
-				res = req.GetResponse()
-			Catch w As WebException
-				GoTo NextURL
-			End Try
-
-			Dim ModifiedUrl As String
-			ModifiedUrl = ImageBlogUrl
-			ModifiedUrl = ModifiedUrl.Replace("http://", "")
-			ModifiedUrl = ModifiedUrl.Replace("/", "")
-
-			Dim ImageURLPath As String = Application.StartupPath & "\Images\System\URL Files\" & ModifiedUrl & ".txt"
-
-			If File.Exists(ImageURLPath) Then
-				Dim URLReader As New StreamReader(ImageURLPath)
-				While URLReader.Peek <> -1
-					BlogListOld.Add(URLReader.ReadLine)
-				End While
-
-				URLReader.Close()
-				URLReader.Dispose()
-			End If
-
-			Dim DupeList As New List(Of String)
-			DupeList.Clear()
-
-			Dim DislikeList As New List(Of String)
-			DislikeList.Clear()
-
-			If File.Exists(ImageURLPath) Then
-				Dim DupeCheck As New StreamReader(ImageURLPath)
-
-				While DupeCheck.Peek <> -1
-					DupeList.Add(DupeCheck.ReadLine())
-				End While
-
-				DupeCheck.Close()
-				DupeCheck.Dispose()
-
-			End If
-
-			If File.Exists(Application.StartupPath & "\Images\System\DislikedImageURLs.txt") Then
-				Dim DislikeCheck As New StreamReader(Application.StartupPath & "\Images\System\DislikedImageURLs.txt")
-
-				While DislikeCheck.Peek <> -1
-					DislikeList.Add(DislikeCheck.ReadLine())
-				End While
-
-				DislikeCheck.Close()
-				DislikeCheck.Dispose()
-
-			End If
-
-
-
-Scrape:
-
-
-
-
-
-			ImageAdded = False
-
-			BlogCycle += 50
-
-
-
-			If Form1.WIExit = True Then GoTo ExitScrape
-
-			Dim doc As XmlDocument = New XmlDocument()
-
-			Try
-				ImageBlogUrl = ImageBlogUrl.Replace("/", "")
-				ImageBlogUrl = ImageBlogUrl.Replace("http:", "http://")
-				Debug.Print("ImageBlogURL = " & ImageBlogUrl)
-				doc.Load(ImageBlogUrl & "/api/read?start=" & BlogCycle & "&num=50")
-			Catch ex As Exception
-			End Try
-
-			If FirstPass = False Then
-				Try
-					For Each node As XmlNode In doc.DocumentElement.SelectNodes("//posts")
-						Dim PostsCount As Integer = node.Attributes.ItemOf("total").InnerText
-						ExactPostsCount = PostsCount
-						PostsCount = RoundUpToNearest(PostsCount, 50)
-						Debug.Print("PostsCount = " & PostsCount)
-					Next
-					FirstPass = True
-				Catch
-					FirstPass = False
-					GoTo NextURL
-				End Try
-			End If
-
-
-
-
-			For Each node As XmlNode In doc.DocumentElement.SelectNodes("//photo-url")
-				Application.DoEvents()
-				If Form1.WIExit = True Then GoTo ExitScrape
-				If node.Attributes.ItemOf("max-width").InnerText = 1280 Then
-					PostsInt += 1
-					ImageAdded = True
-
-					If DupeList.Contains(node.InnerXml) Then
-						Debug.Print("DUPELIST")
-						TotalURLCount += NewURLCount
-						GoTo ExitScrape
-					End If
-
-
-
-
-					Try
-						BlogListNew.Add(node.InnerXml)
-						NewURLCount += 1
-						LBLMaintenance.Text = BlogUrlInfo & Environment.NewLine & NewURLCount & " new files"
-
-					Catch
-						GoTo ExitScrape
-					End Try
-
-					If CancelRebuild = True Then
-						PBMaintenance.Value = 0
+                        '▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+                        '                                            All Errors
+                        '▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+                        Throw
+					Finally
+                        '⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑ Finally ⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑
+                        LBLMaintenance.Text = String.Empty
 						PBCurrent.Value = 0
-						LBLMaintenance.Text = ""
-						CancelRebuild = False
-						BTNMaintenanceRebuild.Enabled = True
-						BTNMaintenanceCancel.Enabled = False
-						BTNMaintenanceRefresh.Enabled = True
-						BTNMaintenanceValidate.Enabled = True
-						Return
-					End If
+						PBMaintenance.Value = 0
+					End Try
+				Case BTNMaintenanceRebuild.Name
+                    '**************************************************************************************************************
+                    '                                             Rebuild URL-Files
+                    '**************************************************************************************************************
+                    Try
+                        ' Run Backgroundworker
+                        Dim __tmpResult As URL_File_BGW.MaintainUrlResult = BWURLFiles.RebuildURLFilesAsync()
 
+                        ' Activate the URL-Files
+                        __tmpResult.MaintainedUrlFiles.ForEach(AddressOf URL_File_Set)
 
-					Form1.ApproveImage = 0
-
-				End If
-
-			Next
-
-
-
-			If ImageAdded = True Then GoTo Scrape
-
-ExitScrape:
-
-
-			Form1.WIExit = False
-
-
-
-			If File.Exists(ImageURLPath) Then My.Computer.FileSystem.DeleteFile(ImageURLPath)
-
-			Dim BlogCombine As New List(Of String)
-
-			For i As Integer = 0 To BlogListNew.Count - 1
-				BlogCombine.Add(BlogListNew(i))
-				'Debug.Print("BLN " & i & ": " & BlogListNew(i))
-			Next
-
-			If BlogListOld.Count > 0 Then
-				' Debug.Print(BlogListOld.Count)
-				For i As Integer = 0 To BlogListOld.Count - 1
-					BlogCombine.Add(BlogListOld(i))
-					' Debug.Print("BLO " & i & ": " & BlogListOld(i))
-				Next
-
+						If __tmpResult.Cancelled Then
+							MessageBox.Show(Me, "Rebuilding URL-File has been aborted after " & __tmpResult.MaintainedUrlFiles.Count & " URL-Files." &
+											vbCrLf & __tmpResult.ModifiedLinkCount & " dead URLs have been removed.",
+											"Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
+						ElseIf __tmpResult.ErrorText.Capacity > 0
+							MessageBox.Show(Me, "URL Files have been rebuilded with errors!" &
+											vbCrLf & vbCrLf & __tmpResult.ModifiedLinkCount & " dead URLs have been removed." &
+											vbCrLf & vbCrLf & __tmpResult.LinkCountTotal & " URLs in total." &
+											vbCrLf & vbCrLf & String.Join(vbCrLf, __tmpResult.ErrorText),
+											"Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
+						Else
+							MessageBox.Show(Me, "All URL Files have been rebuilded!" &
+											vbCrLf & vbCrLf & __tmpResult.ModifiedLinkCount & " dead URLs have been removed." &
+											vbCrLf & vbCrLf & __tmpResult.LinkCountTotal & " URLs in total.",
+											"Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
+						End If
+					Catch
+                        '▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+                        '                                            All Errors
+                        '▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+                        Throw
+					Finally
+                        '⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑ Finally ⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑
+                        LBLMaintenance.Text = String.Empty
+						PBCurrent.Value = 0
+						PBMaintenance.Value = 0
+					End Try
+			End Select
+		Catch ex As Exception
+            '▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+            '                                            All Errors
+            '▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+            If ex.InnerException IsNot Nothing Then
+                ' If an Error ocurred in the other Thread, initial Exception is innner one.
+                MsgBox(ex.InnerException.Message, MsgBoxStyle.Critical, "Error Creating URL-File")
+			Else
+                ' Otherwise show it normal.
+                MsgBox(ex.Message, MsgBoxStyle.Critical, "Error Creating URL-File")
 			End If
-
-
-
-
-
-
-
-
-			'Dim objWriter As New System.IO.StreamWriter(ImageURLPath)
-
-
-			' objWriter.WriteLine(BlogCombine(i))
-			Dim fs As New FileStream(ImageURLPath, FileMode.Create)
-			Dim sw As New StreamWriter(fs)
-			For i As Integer = 0 To BlogCombine.Count - 1
-				If i <> BlogCombine.Count - 1 Then
-					sw.WriteLine(BlogCombine(i))
-				Else
-					sw.Write(BlogCombine(i))
-				End If
-			Next
-			sw.Close()
-			sw.Dispose()
-			fs.Close()
-			fs.Dispose()
-
-
-
-
-
-			' For i As Integer = 0 To BlogCombine.Count - 1
-			'If Not i = BlogCombine.Count - 1 Then
-			'My.Computer.FileSystem.WriteAllText(ImageURLPath, BlogCombine(i) & Environment.NewLine, True)
-			';Else
-			'My.Computer.FileSystem.WriteAllText(ImageURLPath, BlogCombine(i), True)
-			'End If
-			' Debug.Print(BlogCombine(i))
-			'Next
-
-			If Not URLFileList.Items.Contains(ModifiedUrl) Then
-				URLFileList.Items.Add(ModifiedUrl)
-				For i As Integer = 0 To URLFileList.Items.Count - 1
-					If URLFileList.Items(i) = ModifiedUrl Then URLFileList.SetItemChecked(i, True)
-				Next
-			End If
-
-			Dim FileStream As New System.IO.FileStream(Application.StartupPath & "\Images\System\URLFileCheckList.cld", IO.FileMode.Create)
-			Dim BinaryWriter As New System.IO.BinaryWriter(FileStream)
-			For i = 0 To URLFileList.Items.Count - 1
-				BinaryWriter.Write(CStr(URLFileList.Items(i)))
-				BinaryWriter.Write(CBool(URLFileList.GetItemChecked(i)))
-			Next
-			BinaryWriter.Close()
-			FileStream.Dispose()
-
-
-			FirstPass = False
-
-			PBMaintenance.Value += 1
-
-NextURL:
-		Next
-
-		PBMaintenance.Value = PBMaintenance.Maximum
-
-		MessageBox.Show(Me, "All URL Files have been refreshed!" & Environment.NewLine & Environment.NewLine & TotalURLCount & " new URLs have been added.", "Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
-
-		LBLMaintenance.Text = ""
-
-		BTNMaintenanceRebuild.Enabled = True
-		BTNMaintenanceRefresh.Enabled = True
-		BTNMaintenanceCancel.Enabled = False
-		BTNMaintenanceValidate.Enabled = True
-
-		PBMaintenance.Value = 0
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+		Finally
+            '⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑ Finally ⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑⚑
+            ' Restore the initial State of the Buttons
+            __PreEnabled.ForEach(Sub(x) x.Enabled = True)
+			__PreDisabled.ForEach(Sub(x) x.Enabled = False)
+		End Try
 	End Sub
 
+    ''' =========================================================================================================
+    ''' <summary>
+    ''' Activates the specified is activaed in Listbox and saves the Listboxstate.
+    ''' </summary>
+    ''' <param name="URL_FileName"></param>
+    Private Sub URL_File_Set(ByVal URL_FileName As String)
+		Try
+            ' Set the new URL-File
+            If Not URLFileList.Items.Contains(URL_FileName) Then
+				URLFileList.Items.Add(URL_FileName)
+				For i As Integer = 0 To URLFileList.Items.Count - 1
+					If URLFileList.Items(i) = URL_FileName Then URLFileList.SetItemChecked(i, True)
+				Next
+			End If
+            ' Save ListState
+            Using FileStream As New System.IO.FileStream(Application.StartupPath & "\Images\System\URLFileCheckList.cld", IO.FileMode.Create)
+				Using BinaryWriter As New System.IO.BinaryWriter(FileStream)
+					For i = 0 To URLFileList.Items.Count - 1
+						BinaryWriter.Write(CStr(URLFileList.Items(i)))
+						BinaryWriter.Write(CBool(URLFileList.GetItemChecked(i)))
+					Next
+					BinaryWriter.Close()
+				End Using
+			End Using
+		Catch ex As Exception
+			Throw
+		End Try
+	End Sub
+#Region "-------------------------------------- Backgroundworker URL Files --------------------------------------"
 
+	''' =========================================================================================================
+	''' <summary>
+	''' This Event is used, to gather Variables, for the BackgroundThread, the User can change during runtime.
+	''' </summary>
+	''' <param name="sender"></param>
+	''' <param name="e"></param>
+	Private Sub BWURLFiles_URLCreate_User_Interactions(ByVal sender As URL_File_BGW, ByRef e As URL_File_BGW.UserActions) Handles BWURLFiles.URL_FileCreate_UserInteractions
+		If Me.InvokeRequired Then
+			Dim Callbak As New URL_File_BGW.URL_FileCreate_UserInteractions_Delegate(AddressOf BWURLFiles_URLCreate_User_Interactions)
+			Me.Invoke(Callbak, sender, e)
+		Else
+			e.ReviewImages = CBWIReview.Checked
+			e.ApproveImage = Form1.ApproveImage
+			e.SaveImages = CBWISaveToDisk.Checked
+			e.ImgSaveDir = TBWIDirectory.Text
+		End If
+	End Sub
 
+    ''' =========================================================================================================
+    ''' <summary>
+    ''' This Event will be triggered, when the Working Stage of the BGW changes
+    ''' </summary>
+    ''' <param name="Sender"></param>
+    ''' <param name="e"></param>
+    Private Sub BWURLFiles_ProgressChanged(ByVal Sender As Object, ByRef e As URL_File_BGW.URL_File_ProgressChangedEventArgs) Handles BWURLFiles.URL_File_ProgressChanged
+		If Me.InvokeRequired Then
+            ' Beware: Event is fired in Worker Thread, so you need to do a Function Callback.
+            Dim CallBack As New URL_File_BGW.URL_File_ProgressChanged_Delegate(AddressOf BWURLFiles_ProgressChanged)
+			Me.Invoke(CallBack, Sender, e)
+		Else
+            ' Reset remanent Marker for Image Approval
+            If Form1.ApproveImage <> 0 Then Form1.ApproveImage = 0
+			Select Case e.CurrentTask
+				Case URL_File_Tasks.CreateURLFile
+                    '===============================================================================
+                    '                           Create URL-File
+                    '===============================================================================
+                    Select Case e.ActStage
+                        ' ------------------------ Image Approval -------------------------------
+                        Case WorkingStages.ImageApproval
+							If e.ImageToReview IsNot Nothing Then
+                                ' Dispose old Image & Set new Image
+                                Try : WebPictureBox.Image.Dispose() : Catch : End Try
+								WebPictureBox.Image = e.ImageToReview
+                                ' Enabled UI Elements
+                                BTNWIContinue.Enabled = True
+								BTNWIAddandContinue.Enabled = True
+							End If
+						Case WorkingStages.Writing_File
+                            ' ---------------------- Write to File -------------------------------
+                            'State info to User
+                            LBLWebImageCount.Text = "Writing"
+                            ' At this state no cnancel possible
+                            BTNWICancel.Enabled = False
+							WebPictureBox.Image = Nothing
+						Case Else
+                            ' ---------------------- Everthing else ------------------------------
+                            ' Refresh Progressbars
+                            WebImageProgressBar.Maximum = e.BlogPageTotal + 1
+							WebImageProgressBar.Value = e.BlogPage
+                            ' Disable Image Approval-UI
+                            BTNWIContinue.Enabled = False
+							BTNWIAddandContinue.Enabled = False
+                            ' Inform User about BGW-State
+                            LBLWebImageCount.Text = String.Format("{0}/{1} ({2})", e.BlogPage, e.BlogPageTotal, e.ImageCount)
+					End Select
+				Case Else
+                    '===============================================================================
+                    '                           Refresh URL-File
+                    '===============================================================================
+                    LBLMaintenance.Text = e.InfoText
+					PBCurrent.Maximum = e.BlogPageTotal
+					PBCurrent.Value = e.BlogPage
+					PBMaintenance.Maximum = e.OverallProgressTotal
+					PBMaintenance.Value = e.OverallProgress
+			End Select
+		End If
+	End Sub
 
+#End Region
 
-	Function RoundUpToNearest(Value As Integer, nearest As Integer) As Integer
-		Return CInt(Math.Ceiling(Value / nearest) * nearest)
-	End Function
 
 	Private Sub WebPictureBox_MouseWheel(sender As Object, e As System.Windows.Forms.MouseEventArgs) Handles WebPictureBox.MouseWheel
 
@@ -5625,7 +5225,7 @@ NextURL:
 	End Sub
 
 	Private Sub BTNCancel_Click(sender As System.Object, e As System.EventArgs) Handles BTNWICancel.Click
-		URLCancel = True
+		If BWURLFiles.IsBusy Then BWURLFiles.CancelAsync()
 	End Sub
 
 	Private Sub BTNWIRemove_Click(sender As System.Object, e As System.EventArgs) Handles BTNWIRemove.Click
@@ -12082,37 +11682,8 @@ WhyUMakeMeDoDis:
 		My.Settings.Save()
 	End Sub
 
-
-
-
-	Private Sub BTNMaintenance_Click(sender As System.Object, e As System.EventArgs) Handles BTNMaintenanceRebuild.Click
-
-		CancelRebuild = False
-		BTNMaintenanceRebuild.Enabled = False
-		BTNMaintenanceRefresh.Enabled = False
-		BTNMaintenanceValidate.Enabled = False
-		BTNMaintenanceCancel.Enabled = True
-
-		BWRebuildURLFiles.RunWorkerAsync()
-
-
-
-	End Sub
-
-	Private Sub BTNMaintenanceRefresh_Click(sender As System.Object, e As System.EventArgs) Handles BTNMaintenanceRefresh.Click
-
-		CancelRebuild = False
-		BTNMaintenanceRebuild.Enabled = False
-		BTNMaintenanceRefresh.Enabled = False
-		BTNMaintenanceValidate.Enabled = False
-		BTNMaintenanceCancel.Enabled = True
-
-		BWRefreshURLFiles.RunWorkerAsync()
-
-	End Sub
-
 	Private Sub BTNMaintenanceValidate_Click(sender As System.Object, e As System.EventArgs) Handles BTNMaintenanceValidate.Click
-		CancelRebuild = False
+		'TODO: ValidateLocalFiles Change to proper Backgroundworker usage
 		BTNMaintenanceRebuild.Enabled = False
 		BTNMaintenanceRefresh.Enabled = False
 		BTNMaintenanceValidate.Enabled = False
@@ -12121,44 +11692,8 @@ WhyUMakeMeDoDis:
 		BWValidateLocalFiles.RunWorkerAsync()
 	End Sub
 
-	Private Sub BWCreateFiles_DoWork(sender As System.Object, e As System.ComponentModel.DoWorkEventArgs) Handles BWCreateURLFiles.DoWork
-
-
-		Control.CheckForIllegalCrossThreadCalls = False
-
-		Thr = New Threading.Thread(New Threading.ThreadStart(AddressOf CreateURLFiles))
-		Thr.SetApartmentState(ApartmentState.STA)
-		Thr.Start()
-
-	End Sub
-
-	Private Sub BWRefreshURLFiles_DoWork(sender As System.Object, e As System.ComponentModel.DoWorkEventArgs) Handles BWRefreshURLFiles.DoWork
-
-
-		Control.CheckForIllegalCrossThreadCalls = False
-
-		Thr = New Threading.Thread(New Threading.ThreadStart(AddressOf CombineURLFiles))
-		Thr.SetApartmentState(ApartmentState.STA)
-		Thr.Start()
-
-	End Sub
-
-
-
-	Private Sub BWRebuildURLFiles_DoWork(sender As System.Object, e As System.ComponentModel.DoWorkEventArgs) Handles BWRebuildURLFiles.DoWork
-
-
-		Control.CheckForIllegalCrossThreadCalls = False
-
-		Thr = New Threading.Thread(New Threading.ThreadStart(AddressOf RebuildURLs))
-		Thr.SetApartmentState(ApartmentState.STA)
-		Thr.Start()
-
-	End Sub
-
-
 	Private Sub BWValidateLocalFiles_DoWork(sender As System.Object, e As System.ComponentModel.DoWorkEventArgs) Handles BWValidateLocalFiles.DoWork
-
+		'TODO: ValidateLocalFiles Change to proper Backgroundworker usage
 
 		Control.CheckForIllegalCrossThreadCalls = False
 
@@ -12168,310 +11703,8 @@ WhyUMakeMeDoDis:
 
 	End Sub
 
-	Public Sub RebuildURLs()
-
-		Dim NewURLCount As Integer
-
-
-
-		Dim MaintString As System.Collections.ObjectModel.ReadOnlyCollection(Of String)
-		MaintString = My.Computer.FileSystem.GetFiles(Application.StartupPath & "\Images\System\URL Files")
-
-		Dim MaintCount As Integer = CStr(MaintString.Count)
-		PBMaintenance.Maximum = MaintCount
-		PBMaintenance.Value = 0
-
-
-
-
-
-		For Each foundFile As String In My.Computer.FileSystem.GetFiles(Application.StartupPath & "\Images\System\URL Files\", FileIO.SearchOption.SearchTopLevelOnly, "*.txt")
-
-			If CancelRebuild = True Then
-				PBMaintenance.Value = 0
-				PBCurrent.Value = 0
-				LBLMaintenance.Text = ""
-				CancelRebuild = False
-				BTNMaintenanceRebuild.Enabled = True
-				BTNMaintenanceCancel.Enabled = False
-				BTNMaintenanceRefresh.Enabled = True
-				BTNMaintenanceValidate.Enabled = True
-				Return
-			End If
-
-			PBCurrent.Value = 0
-
-
-			Debug.Print("FoundFile = " & foundFile)
-
-			Dim FirstPass As Boolean = False
-			Dim ExactPostsCount As Integer
-			Dim PostsInt As Integer = 0
-			Dim ImageAdded As Boolean
-			Dim BlogCycle As Integer
-			BlogCycle = -50
-
-			NewURLCount = 0
-
-			Dim BlogListOld As New List(Of String)
-			Dim BlogListNew As New List(Of String)
-
-			Dim ImageBlogUrl As String = foundFile.Replace(Application.StartupPath & "\Images\System\URL Files\", "")
-			Dim BlogUrlInfo As String = ImageBlogUrl
-
-			ImageBlogUrl = ImageBlogUrl.Replace(".txt", "")
-			ImageBlogUrl = "http://" & ImageBlogUrl
-
-
-			Dim req As System.Net.WebRequest
-			Dim res As System.Net.WebResponse
-
-			req = System.Net.WebRequest.Create(ImageBlogUrl)
-
-			Try
-				res = req.GetResponse()
-			Catch w As WebException
-				GoTo NextURL
-			End Try
-
-			Dim ModifiedUrl As String
-			ModifiedUrl = ImageBlogUrl
-			ModifiedUrl = ModifiedUrl.Replace("http://", "")
-			ModifiedUrl = ModifiedUrl.Replace("/", "")
-
-			Dim ImageURLPath As String = Application.StartupPath & "\Images\System\URL Files\" & ModifiedUrl & ".txt"
-
-
-
-			Dim DupeList As New List(Of String)
-			DupeList.Clear()
-
-			Dim DislikeList As New List(Of String)
-			DislikeList.Clear()
-
-			If File.Exists(foundFile) Then
-
-				My.Computer.FileSystem.CopyFile(foundFile, foundFile & ".bak", Microsoft.VisualBasic.FileIO.UIOption.AllDialogs, Microsoft.VisualBasic.FileIO.UICancelOption.DoNothing)
-
-
-				Dim DupeCheck As New StreamReader(foundFile)
-
-				While DupeCheck.Peek <> -1
-					DupeList.Add(DupeCheck.ReadLine())
-				End While
-
-				DupeCheck.Close()
-				DupeCheck.Dispose()
-				My.Computer.FileSystem.DeleteFile(foundFile)
-			End If
-
-
-
-
-
-			If File.Exists(Application.StartupPath & "\Images\System\DislikedImageURLs.txt") Then
-				Dim DislikeCheck As New StreamReader(Application.StartupPath & "\Images\System\DislikedImageURLs.txt")
-
-				While DislikeCheck.Peek <> -1
-					DislikeList.Add(DislikeCheck.ReadLine())
-				End While
-
-				DislikeCheck.Close()
-				DislikeCheck.Dispose()
-
-			End If
-
-
-
-Scrape:
-
-
-
-
-
-			ImageAdded = False
-
-			BlogCycle += 50
-
-
-
-			If Form1.WIExit = True Then GoTo ExitScrape
-
-			Dim doc As XmlDocument = New XmlDocument()
-
-			Try
-				ImageBlogUrl = ImageBlogUrl.Replace("/", "")
-				ImageBlogUrl = ImageBlogUrl.Replace("http:", "http://")
-				Debug.Print("ImageBlogURL = " & ImageBlogUrl)
-				doc.Load(ImageBlogUrl & "/api/read?start=" & BlogCycle & "&num=50")
-			Catch ex As Exception
-			End Try
-
-			If FirstPass = False Then
-				Try
-					For Each node As XmlNode In doc.DocumentElement.SelectNodes("//posts")
-						Dim PostsCount As Integer = node.Attributes.ItemOf("total").InnerText
-						ExactPostsCount = PostsCount
-						PBCurrent.Maximum = ExactPostsCount
-						PostsCount = RoundUpToNearest(PostsCount, 50)
-						Debug.Print("PostsCount = " & PostsCount)
-					Next
-					LBLMaintenance.Text = "Validating URL Files" & Environment.NewLine & Path.GetFileName(foundFile)
-					FirstPass = True
-				Catch
-					FirstPass = False
-					GoTo NextURL
-				End Try
-			End If
-
-
-
-
-			For Each node As XmlNode In doc.DocumentElement.SelectNodes("//photo-url")
-				Application.DoEvents()
-				If Form1.WIExit = True Then GoTo ExitScrape
-				If node.Attributes.ItemOf("max-width").InnerText = 1280 Then
-					PostsInt += 1
-					ImageAdded = True
-
-					If PBCurrent.Value < PBCurrent.Maximum Then PBCurrent.Value += 1
-
-
-
-					If BlogListNew.Contains(node.InnerXml) Then
-						'MsgBox(node.InnerXml & " ALREADY HAS!")
-						GoTo AlreadyHas
-					End If
-
-					NewURLCount += 1
-
-
-
-					Try
-						BlogListNew.Add(node.InnerXml)
-
-					Catch
-						GoTo ExitScrape
-					End Try
-					If PBCurrent.Value >= PBCurrent.Maximum Then GoTo ExitScrape
-
-AlreadyHas:
-
-					Form1.ApproveImage = 0
-
-				End If
-
-				If CancelRebuild = True Then
-					PBMaintenance.Value = 0
-					PBCurrent.Value = 0
-					LBLMaintenance.Text = ""
-					CancelRebuild = False
-
-					If File.Exists(foundFile & ".bak") Then
-						My.Computer.FileSystem.CopyFile(foundFile & ".bak", foundFile, Microsoft.VisualBasic.FileIO.UIOption.AllDialogs, Microsoft.VisualBasic.FileIO.UICancelOption.DoNothing)
-						My.Computer.FileSystem.DeleteFile(foundFile & ".bak")
-					End If
-
-					BTNMaintenanceRebuild.Enabled = True
-					BTNMaintenanceCancel.Enabled = False
-					BTNMaintenanceRefresh.Enabled = True
-					BTNMaintenanceValidate.Enabled = True
-
-					Return
-				End If
-
-			Next
-
-
-
-			If ImageAdded = True Then GoTo Scrape
-
-ExitScrape:
-
-
-			Form1.WIExit = False
-
-
-
-			If File.Exists(ImageURLPath) Then My.Computer.FileSystem.DeleteFile(ImageURLPath)
-
-			Dim BlogCombine As New List(Of String)
-
-			For i As Integer = 0 To BlogListNew.Count - 1
-				BlogCombine.Add(BlogListNew(i))
-				'Debug.Print("BLN " & i & ": " & BlogListNew(i))
-			Next
-
-
-
-
-			Dim fs As New FileStream(ImageURLPath, FileMode.Create)
-			Dim sw As New StreamWriter(fs)
-			For i As Integer = 0 To BlogCombine.Count - 1
-				If i <> BlogCombine.Count - 1 Then
-					sw.WriteLine(BlogCombine(i))
-				Else
-					sw.Write(BlogCombine(i))
-				End If
-			Next
-			sw.Close()
-			sw.Dispose()
-			fs.Close()
-			fs.Dispose()
-
-
-
-
-			' For i As Integer = 0 To BlogCombine.Count - 1
-			'If Not i = BlogCombine.Count - 1 Then
-			'My.Computer.FileSystem.WriteAllText(ImageURLPath, BlogCombine(i) & Environment.NewLine, True)
-			';Else
-			'My.Computer.FileSystem.WriteAllText(ImageURLPath, BlogCombine(i), True)
-			'End If
-			' Debug.Print(BlogCombine(i))
-			'Next
-
-			If Not URLFileList.Items.Contains(ModifiedUrl) Then
-				URLFileList.Items.Add(ModifiedUrl)
-				For i As Integer = 0 To URLFileList.Items.Count - 1
-					If URLFileList.Items(i) = ModifiedUrl Then URLFileList.SetItemChecked(i, True)
-				Next
-			End If
-
-			Dim FileStream As New System.IO.FileStream(Application.StartupPath & "\Images\System\URLFileCheckList.cld", IO.FileMode.Create)
-			Dim BinaryWriter As New System.IO.BinaryWriter(FileStream)
-			For i = 0 To URLFileList.Items.Count - 1
-				BinaryWriter.Write(CStr(URLFileList.Items(i)))
-				BinaryWriter.Write(CBool(URLFileList.GetItemChecked(i)))
-			Next
-			BinaryWriter.Close()
-			FileStream.Dispose()
-
-
-			FirstPass = False
-
-			PBMaintenance.Value += 1
-
-			If File.Exists(foundFile & ".bak") Then My.Computer.FileSystem.DeleteFile(foundFile & ".bak")
-
-NextURL:
-		Next
-
-		PBMaintenance.Value = PBMaintenance.Maximum
-
-		MessageBox.Show(Me, "All URL Files have been rebuilt!", "Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
-
-		PBMaintenance.Value = 0
-		PBCurrent.Value = 0
-
-
-	End Sub
-
 	Private Sub Button1_Click_1(sender As System.Object, e As System.EventArgs) Handles BTNMaintenanceCancel.Click
-
-		CancelRebuild = True
-
-
+		If BWURLFiles.IsBusy Then BWURLFiles.CancelAsync()
 	End Sub
 
 

--- a/Tease AI/Tease AI.vbproj
+++ b/Tease AI/Tease AI.vbproj
@@ -161,6 +161,9 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <Compile Include="Classes\URL_Files_BGW.vb">
+      <SubType>Component</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Form1.resx">


### PR DESCRIPTION
 Fixes Bug, when trying to creating a URL-File, with activated Image Review. There was no reaction to clicks on "Continue" and "Add and continue".

 Improvements :
- Fixed all CrossthreadCalls, wich caused the System to malfunction, with UserInteraction.
- Removed all hard-coded Folder and File Strings.
- Removed redundant Code.
- If you review and download images, the image was downloaded twice.
- The Blog-XML was downloaded with XML-Doc. After you scrapted an URL, you sometimes couldn't scrape it again.
- Deadlinks were imported again.
- Adding an URL to DislikeList was only writing to file, so a disliked URL could get into File, if a blog contains it twice.

CodeChanges:

Added Class: URL_File_BGW
Removed Var: URLCancel
Removed Var: CancelRebuild (it seems auditing Scripts and validating Local Files didn't use it.)
Changed Sub: Button38_Click (Handles now BTNWICreateURL.Click, BTNMaintenanceRefresh.Click, BTNMaintenanceRebuild.click)
Removed Sub: CreateURLFiles
REmoved Sub: CombineURLFiles
Removed Sub: RoundUpToNearest
removed Sub: RebuildURLs
Added Function: URL_File_Set
Added Sub: BWURLFiles_URLCreate_User_Interactions (to get UserInputs during BGW)
Added Sub: BWURLFiles_ProgressChanged (To Update UI during BGW)
Changed Sub: BTNCancel_Click
Removed Sub: BTNMaintenance_Click
Removed Sub: BTNMaintenanceRefresh_Click
Removed Sub: RebuildURLs
Changed Sub: Button1_Click_1

Designer:
Added URL_File_BGW: BWURLFiles
REmoved BGW: BWCreateURLFiles
REmoved BGW: BWRebuildURLFiles
REmoved BGW: BWRefreshURLFiles

Summary:
Smaller Filesize of Form2.vb. No more CrossThreadErrors, when working with URL-Files.
All URL-File related code has been outsourced for better maintainability. Full compatiblity with previous versions.

KnownIssues:
At Visual studio Startup, sometimes there can be an Error, that the Class URL_File_BGW is unknown. That's always with Runtime compiled Classes. Starting the solution will work properly and afterwards the error is gone.
As for there is no consistent errorhandling in Tease-AI it can occur that the Bgw-Catch-Blocks will receive Exceptions from other funtions. This issue can only be fixed by adding consistent errorhandling to the rest of the program.
